### PR TITLE
Fix network issue with git-sync-deps

### DIFF
--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -508,7 +508,21 @@ class ConanSkia(ConanFile):
     def build(self):
         # activate-emsdk fails on Windows for some reason.
         os.environ["GIT_SYNC_DEPS_SKIP_EMSDK"] = "1"
-        self.run("python3 tools/git-sync-deps")
+
+        # times to retry before giving up
+        retries = 3
+
+        # to store git-sync-deps return value
+        gsd_return_value = 1
+
+        for _ in range(retries):
+            gsd_return_value = self.run("python3 tools/git-sync-deps", ignore_errors=True)
+            if gsd_return_value == 0:
+                break
+
+        if gsd_return_value != 0:
+            raise RuntimeError(f"tools/git-sync-deps failed after {retries} attempts")
+
         del os.environ["GIT_SYNC_DEPS_SKIP_EMSDK"]
 
         if self.options.use_expat and self.options.use_system_expat and self.options.use_conan_expat:

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -509,19 +509,16 @@ class ConanSkia(ConanFile):
         # activate-emsdk fails on Windows for some reason.
         os.environ["GIT_SYNC_DEPS_SKIP_EMSDK"] = "1"
 
-        # times to retry before giving up
-        retries = 3
-
-        # to store git-sync-deps return value
+        gsd_max_retries = 3
         gsd_return_value = 1
 
-        for _ in range(retries):
+        for _ in range(gsd_max_retries):
             gsd_return_value = self.run("python3 tools/git-sync-deps", ignore_errors=True)
             if gsd_return_value == 0:
                 break
 
         if gsd_return_value != 0:
-            raise RuntimeError(f"tools/git-sync-deps failed after {retries} attempts")
+            raise RuntimeError(f"tools/git-sync-deps failed after {gsd_max_retries} attempts")
 
         del os.environ["GIT_SYNC_DEPS_SKIP_EMSDK"]
 


### PR DESCRIPTION
### What
Modified the `conanfile.py` to run the  `python3 tools/git-sync-deps` command multiple times (if necessary) to ensure that the dependencies are installed properly installed.

### Why
The `git-sync-deps` scripts uses multiple threads to concurrently get the dependencies which can cause network timeouts on lower bandwidths leading to the script failing and the entire recipe failing as well.

### How
After a little research through the issues on the official repo of Skia, I figured out that there were no direct way to gracefully solve this issue. One guy on that repo mentioned to just run the script again to resolve the issue and I can confirm from my own experience that that does work (It works because some of the dependencies gets cached and does not need to be downloaded again).

So I have added a simple loop around the call to the `python3 tools/git-sync-deps` command to run it multiple times (3 times in this case) if it keeps failing and throw a `RuntimeError` if it still fails afterwards. This might not be the most streamline solution and a little bit scuff but I couldn't figure out any other solutions.

### Testing
The Github actions ran successfully.