### PR TITLE
Fix issues related to skia modules

### DIFF
--- a/profiles/ios-armv8.profile
+++ b/profiles/ios-armv8.profile
@@ -2,10 +2,10 @@ include(default)
 
 [settings]
 os=iOS
-os.version=17.5
+os.version=18.5
 os.sdk=iphoneos
-os.sdk_version=17.5
+os.sdk_version=18.5
 arch=armv8.3
 compiler=apple-clang
-compiler.version=15.0
+compiler.version=16.0
 compiler.libcxx=libc++

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -720,6 +720,7 @@ class ConanSkia(ConanFile):
         self.run("ninja -C out/conan")
 
     def package(self):
+        source_folder_source = join(self.source_folder, "src")
         source_folder_include = join(self.source_folder, "include")
         source_folder_modules = join(self.source_folder, "modules")
         package_folder_include = join(self.package_folder, "include")
@@ -733,8 +734,13 @@ class ConanSkia(ConanFile):
 
         copy(self, "*.h", source_folder_include, join(package_folder_include, "include"))
 
+        # Some headers in the src folder are needed by some modules due to internal includes
+        copy(self, "*.h", source_folder_source, join(package_folder_include, "src"))
+
         for mod in ["skottie", "skresources", "sksg", "skshaper", "skunicode", "svg"]:
             copy(self, "*.h", join(source_folder_modules, mod, "include"), join(package_folder_include_modules, mod, "include"))
+            # Some headers in the src folders of the modules are needed due to internal includes
+            copy(self, "*.h", join(source_folder_modules, mod, "src"), join(package_folder_include_modules, mod, "src"))
 
         # skcms doesn't have include folder for some reason.
         copy(self, "*.h", join(source_folder_modules, "skcms"), join(package_folder_include_modules, "skcms"))

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -737,7 +737,7 @@ class ConanSkia(ConanFile):
         # Some headers in the src folder are needed by some modules due to internal includes
         copy(self, "*.h", source_folder_source, join(package_folder_include, "src"))
 
-        for mod in ["skottie", "skresources", "sksg", "skshaper", "skunicode", "svg"]:
+        for mod in ["skottie", "skresources", "sksg", "skshaper", "skunicode", "svg", "skparagraph"]:
             copy(self, "*.h", join(source_folder_modules, mod, "include"), join(package_folder_include_modules, mod, "include"))
             # Some headers in the src folders of the modules are needed due to internal includes
             copy(self, "*.h", join(source_folder_modules, mod, "src"), join(package_folder_include_modules, mod, "src"))

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -735,7 +735,8 @@ class ConanSkia(ConanFile):
         copy(self, "*.h", source_folder_include, join(package_folder_include, "include"))
 
         # Some headers in the src folder are needed by some modules due to internal includes
-        copy(self, "*.h", source_folder_source, join(package_folder_include, "src"))
+        for dir in ["core", "base"]:
+            copy(self, "*.h", join(source_folder_source, dir), join(package_folder_include, "src", dir))
 
         for mod in ["skottie", "skresources", "sksg", "skshaper", "skunicode", "svg", "skparagraph"]:
             copy(self, "*.h", join(source_folder_modules, mod, "include"), join(package_folder_include_modules, mod, "include"))

--- a/recipes/skia/all/conanfile.py
+++ b/recipes/skia/all/conanfile.py
@@ -733,7 +733,7 @@ class ConanSkia(ConanFile):
 
         copy(self, "*.h", source_folder_include, join(package_folder_include, "include"))
 
-        for mod in ["skottie", "skresource", "sksg", "skshaper", "skunicode", "svg"]:
+        for mod in ["skottie", "skresources", "sksg", "skshaper", "skunicode", "svg"]:
             copy(self, "*.h", join(source_folder_modules, mod, "include"), join(package_folder_include_modules, mod, "include"))
 
         # skcms doesn't have include folder for some reason.


### PR DESCRIPTION
### What

Modified `conanfile.py` so headers and libraries gets properly copied to the final package.
Also updated the conan profile for iOS.

### Why

1. `skresources` headers were not being copied to the package due to a typo.
2. `skparagraph` was not in the mod list when copying the headers to the package.
3. Some modules require headers from the main `src` directory as well as `src` directories of the modules due to internal includes.
4. Github action runner for `macos-latest` got updated to macOS 15, so the previous conan profile for iOS was using outdated version of the SDK and the apple-clang compiler (The github action for iOS was failing due to this).

### How

1. Fixed typo : `skresource` -> `skresources`.
2. Added `skparagraph` to the mod list when copying the header files.
3. Copy the headers in the `src` directories to the final package.
4. Updated the versions for SDK and apple-clang version in the iOS conan profile.

### Testing

The Github actions ran successfully.